### PR TITLE
fix 2 bugs in ULLMap.java

### DIFF
--- a/lab07/src/ULLMap.java
+++ b/lab07/src/ULLMap.java
@@ -40,6 +40,7 @@ public class ULLMap<K, V>  implements Map61B<K, V> {
             Entry lookup = list.get(key);
             if (lookup == null) {
                 list = new Entry(key, val, list);
+                size = size + 1;
             } else {
                 lookup.val = val;
             }
@@ -88,7 +89,7 @@ public class ULLMap<K, V>  implements Map61B<K, V> {
             if (next == null) {
                 return null;
             }
-            return next.get(key);
+            return next.get(k);
         }
 
         /** Stores the key of the key-value pair of this node in the list. */


### PR DESCRIPTION
Hi, I spotted two minor bugs while playing with the ULLMap class in lab07, and I noticed that these bugs have existed since sp21 or earlier. The first problem is that when new items are added, the size is not increased unless there's nothing in the linked list. The second issue is that the get() method in the inner class should always use the user-wanted key "k" instead of the key of the current Entry instance. Hope this information is helpful.